### PR TITLE
Fix star email owner check

### DIFF
--- a/mail-worker/src/service/star-service.js
+++ b/mail-worker/src/service/star-service.js
@@ -15,9 +15,9 @@ const starService = {
 		if (!email) {
 			throw new BizError('星标的邮件不存在');
 		}
-		if (!email.userId === userId) {
-			throw new BizError('星标的邮件非当前用户所有');
-		}
+                if (email.userId !== userId) {
+                        throw new BizError('星标的邮件非当前用户所有');
+                }
 		const exist = await orm(c).select().from(star).where(
 			and(
 				eq(star.userId, userId),


### PR DESCRIPTION
## Summary
- correct the star service owner verification logic

## Testing
- `npx vitest run --silent` *(fails: `npx: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687d2060c8088320b75d7fe12957d5ee